### PR TITLE
Clean Metaphlan table

### DIFF
--- a/scripts/1a_datacleaning_helius.R
+++ b/scripts/1a_datacleaning_helius.R
@@ -18,7 +18,7 @@ yesno_auto <- function(x) {
 zero_one <- function(x) fct_recode(x, "No"="0", "Yes"="1")
 
 ## HELIUS data
-meta <- haven::read_sav("data/250606_HELIUS data Barbara Verhaar.sav")
+meta <- haven::read_sav("data/raw/250606_HELIUS data Barbara Verhaar.sav")
 names(meta)
 
 df_new <- meta |> 
@@ -300,5 +300,5 @@ df_new2 <- df_new |>
 
 dim(df_new2)
 
-saveRDS(df_new2, "data/HELIUSmetadata_clean.RDS")
+saveRDS(df_new2, "data/processed/HELIUSmetadata_clean.RDS")
   

--- a/scripts/1a_datacleaning_helius.R
+++ b/scripts/1a_datacleaning_helius.R
@@ -304,5 +304,5 @@ df_new2 <- df_new |>
 
 dim(df_new2)
 
-saveRDS(df_new2, "data/HELIUSmetadata_clean.RDS")
+saveRDS(df_new2, "data/processed/HELIUSmetadata_clean.RDS")
   

--- a/scripts/1a_datacleaning_helius.R
+++ b/scripts/1a_datacleaning_helius.R
@@ -294,11 +294,15 @@ df_new2 <- df_new |>
              "low (men 0-4 gl/w, women 0-2 gl/w)" = "Low (men 0-4 gl/w, women 0-2 gl/w)",
              "moderate (men 5-14 gl/w, women 3-7 gl/w)" = "Moderate (men 5-14 gl/w, women 3-7 gl/w)",
              "high (men >14 gl/w, women >7 gl/wk)" = "High (men >14 gl/w, women >7 gl/wk)"
-           )
+           ),
+
+           # Strip the sample IDs to match metaphlan (without the well no)
+           TongueSampleID = str_extract(TongueSampleID, "[0-9]*_[0-9]*"),
+           ThroatSampleID = str_extract(ThroatSampleID, "[0-9]*_[0-9]*")
     ) |> 
     droplevels()
 
 dim(df_new2)
 
-saveRDS(df_new2, "data/processed/HELIUSmetadata_clean.RDS")
+saveRDS(df_new2, "data/HELIUSmetadata_clean.RDS")
   


### PR DESCRIPTION
**Metadata cleaning and file management:**
* Updated file paths to read the raw HELIUS metadata from `data/raw` and save the cleaned metadata to `data/processed`, improving data organization. 
* Standardized `TongueSampleID` and `ThroatSampleID` in the metadata by extracting consistent sample ID patterns to ensure compatibility with other datasets.

**Biome data processing and taxonomic table refinement:**
* Filtered the biome data to select only species-level entries and cleaned up the `clade_name` field to create a structured taxonomic table, which is then saved separately as `shotgun_taxtable.RDS`.
* Matched and replaced sample IDs in the biome data with the standardized HELIUS IDs, ensuring alignment between datasets.
* Split and saved the processed biome data into tongue and throat datasets, each saved to their respective processed files.

Closes #9 