### PR TITLE
Link 16S sample IDs to HELIUS metadata via ID offset

### DIFF
--- a/scripts/1b_datacleaning_biome.R
+++ b/scripts/1b_datacleaning_biome.R
@@ -143,9 +143,7 @@ ps_nose <- prune_samples(nose_samples, psnoneg)
 sample_names(ps_nose) <- str_remove(sample_names(ps_nose), "_Nose")
 ps_nose
 
-# Save the split phyloseq objects
-saveRDS(ps_throat, "data/processed/ps_throat.RDS")
-saveRDS(ps_nose, "data/processed/ps_nose.RDS")
+# Split phyloseq objects saved later (after HELIUS metadata linkage)
 
 # Rarefaction nose samples
 otu_nose <- t(as(otu_table(ps_nose), "matrix"))
@@ -265,9 +263,35 @@ ps_throat_rarefied # 1626 taxa and 2390 samples
 sample_names(ps_nose_rarefied)
 sample_names(ps_throat_rarefied)
 
-# Save rarefied phyloseq objects
-saveRDS(ps_nose_rarefied, "data/processed/ps_nose_rarefied.RDS")
+# Link 16S samples to HELIUS clinical metadata via ID offset
+# Ext_ID (6-digit) + 1900253 = HELIUS internal ID (7-digit)
+helius_meta <- readRDS("data/processed/HELIUSmetadata_clean.RDS")
+
+add_helius_metadata <- function(ps, helius_meta) {
+  sdata <- data.frame(sample_data(ps))
+  sdata$sample_name_orig <- sample_names(ps)
+  sdata$HELIUS_ID <- paste0("S", as.numeric(sdata$Ext_ID) + 1900253)
+  merged <- left_join(sdata, helius_meta, by = c("HELIUS_ID" = "ID"))
+  rownames(merged) <- merged$sample_name_orig
+  sample_data(ps) <- sample_data(merged)
+  ps
+}
+
+ps_throat_rarefied <- add_helius_metadata(ps_throat_rarefied, helius_meta)
+ps_nose_rarefied <- add_helius_metadata(ps_nose_rarefied, helius_meta)
+ps_throat <- add_helius_metadata(ps_throat, helius_meta)
+ps_nose <- add_helius_metadata(ps_nose, helius_meta)
+
+cat("16S throat rarefied: matched", sum(!is.na(sample_data(ps_throat_rarefied)$Ethnicity)),
+    "/", nsamples(ps_throat_rarefied), "to HELIUS metadata\n")
+cat("16S nose rarefied: matched", sum(!is.na(sample_data(ps_nose_rarefied)$Ethnicity)),
+    "/", nsamples(ps_nose_rarefied), "to HELIUS metadata\n")
+
+# Save phyloseq objects (with HELIUS metadata)
+saveRDS(ps_throat, "data/processed/ps_throat.RDS")
+saveRDS(ps_nose, "data/processed/ps_nose.RDS")
 saveRDS(ps_throat_rarefied, "data/processed/ps_throat_rarefied.RDS")
+saveRDS(ps_nose_rarefied, "data/processed/ps_nose_rarefied.RDS")
 
 # Metagenomics: merge batches
 batch1 <- rio::import("data/raw/combined_table.txt")


### PR DESCRIPTION
## Summary

- Discovered that HELIUS internal IDs and 16S external IDs (Ext_ID) are related by a **constant offset of 1,900,253**: `HELIUS_ID = "S" + (Ext_ID + 1900253)`. This was verified across all 160 shotgun samples where both IDs are known — the offset is identical for every single one.
- Added `add_helius_metadata()` function to `scripts/1b_datacleaning_biome.R` that joins the full HELIUS clinical metadata (ethnicity, age, sex, BMI, medications, lab values, etc.) onto all four 16S phyloseq objects (`ps_throat`, `ps_nose`, and their rarefied versions).
- Generated a standalone mapping file at `data/processed/16s_to_helius_id_mapping.csv` for convenient reuse.

**Match rates:** 2390/2390 (throat rarefied), 2460/2460 (throat), 1241/1242 (nose rarefied), 1853/1854 (nose).

**Validation:** The mapping was sanity-checked by confirming (1) all computed HELIUS_IDs exist in the metadata, (2) all mappings are 1:1 with no duplicates, (3) zero participant overlap with shotgun (expected), and (4) plausible age/sex distributions.

This unblocks all 16S analyses that require ethnicity stratification or clinical covariates.

## Test plan
- [x] Re-run `scripts/1b_datacleaning_biome.R` end-to-end and verify match counts printed to console
- [x] Verify `sample_data(readRDS("data/processed/ps_throat_rarefied.RDS"))$Ethnicity` is populated
- [x] Spot-check a few rows in `data/processed/16s_to_helius_id_mapping.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)