### PR TITLE
Add Figure 1-3 assembly scripts (16S diversity and differential abundance by ethnicity)

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -23,7 +23,9 @@ beta-16s-migration = { cmd = "Rscript scripts/8_beta_diversity_16s_migration.R",
 diffabund-16s = { cmd = "Rscript scripts/9_differential_abundance_16s.R", depends-on = ["clean-biome"], description = "Differential abundance, 16S throat/nose, pairwise ethnicity comparisons (MaAsLin2)" }
 upset-diffabund-16s = { cmd = "Rscript scripts/10_upset_diffabund_16s.R", depends-on = ["diffabund-16s"], description = "Overlap of significant differentially abundant taxa across ethnicity pairs" }
 alpha-shotgun = { cmd = "Rscript scripts/11_alpha_diversity_shotgun.R", depends-on = ["clean-biome"], description = "Alpha diversity, shotgun tongue/throat, stratified by ethnicity" }
-pipeline = { depends-on = ["tableone", "airpollution-participants", "airpollution-amsterdam", "relabund-plots", "alpha-16s", "beta-16s", "beta-16s-migration", "upset-diffabund-16s", "alpha-shotgun"], description = "Run the full analysis pipeline end to end" }
+figure1 = { cmd = "Rscript scripts/12_figure1_assembly.R", depends-on = ["clean-biome", "beta-16s-compute"], description = "Assemble Figure 1: Shannon diversity, weighted UniFrac PCoA, and betadisper panels (16S throat/nose)" }
+figure2 = { cmd = "Rscript scripts/13_figure2_assembly.R", depends-on = ["beta-16s-compute"], description = "Assemble Figure 2: pairwise PERMANOVA (weighted UniFrac) and covariate effects on beta diversity (16S throat/nose)" }
+pipeline = { depends-on = ["tableone", "airpollution-participants", "airpollution-amsterdam", "relabund-plots", "alpha-16s", "beta-16s", "beta-16s-migration", "upset-diffabund-16s", "alpha-shotgun", "figure1", "figure2"], description = "Run the full analysis pipeline end to end" }
 
 [dependencies]
 bioconductor-phyloseq = { version = ">=1.50.0,<2", channel = "bioconda" }
@@ -46,3 +48,4 @@ r-upsetr = ">=1.4.1,<2"
 r-sf = ">=1.0_19,<2"
 r-leaflet = ">=2.2.2,<3"
 r-htmlwidgets = ">=1.6.4,<2"
+r-cowplot = ">=1.2.0,<2"

--- a/scripts/12_figure1_assembly.R
+++ b/scripts/12_figure1_assembly.R
@@ -1,0 +1,302 @@
+## Figure 1 assembly: 16S throat/nose, stratified by ethnicity
+## Panels:
+##   A/B - Shannon diversity (nose/throat)
+##   C/D - Weighted UniFrac PCoA (nose/throat)
+##   E/F - Betadisper, distance to centroid (nose/throat)
+## Also writes a supplement (figure1_supp_braycurtis_pcoa.pdf/.png) with
+## Bray-Curtis PCoA panels A/B for nose/throat side by side.
+## Alpha diversity is recomputed directly from the rarefied phyloseq objects
+## (cheap). The beta diversity panels are rebuilt from the .rds cache written
+## by 7a_beta_diversity_16s_compute.R, so this script never repeats a
+## permutation test - run 7a first (BETA_DIV_TEST_N=<n> for a fast test cache).
+
+## Libraries
+library(here)
+library(tidyverse)
+library(phyloseq)
+library(cowplot)
+library(grid)
+library(ggthemes)
+library(ggpubr)
+
+## Functions
+theme_Publication <- function(base_size=14, base_family="sans") {
+    library(grid)
+    library(ggthemes)
+    library(stringr)
+    (theme_foundation(base_size=base_size, base_family=base_family)
+        + theme(plot.title = element_text(face = "bold",
+                                          size = rel(1.0), hjust = 0.5),
+                text = element_text(),
+                panel.background = element_rect(colour = NA, fill = NA),
+                plot.background = element_rect(colour = NA, fill = NA),
+                panel.border = element_rect(colour = NA),
+                axis.title = element_text(face = "bold",size = rel(0.8)),
+                axis.title.y = element_text(angle=90, vjust =2),
+                axis.title.x = element_text(vjust = -0.2),
+                axis.text = element_text(size = rel(0.7)),
+                axis.text.x = element_text(angle = 0),
+                axis.line = element_line(colour="black"),
+                axis.ticks = element_line(),
+                panel.grid.major = element_line(colour="#f0f0f0"),
+                panel.grid.minor = element_blank(),
+                legend.key = element_rect(colour = NA),
+                legend.position = "bottom",
+                legend.key.size= unit(0.2, "cm"),
+                legend.spacing  = unit(0, "cm"),
+                plot.margin=unit(c(10,5,5,5),"mm"),
+                strip.background=element_rect(colour="#f0f0f0",fill="#f0f0f0"),
+                strip.text = element_text(face="bold"),
+                plot.caption = element_text(size = rel(0.5), face = "italic")
+        ))
+}
+
+## Keep only ethnicity groups with more than n=50 samples (matches Table 1)
+keep_groups <- function(ps, min_n = 50) {
+    counts <- table(sample_data(ps)$EthnicityTotal)
+    names(counts)[counts > min_n]
+}
+
+## PCoA ordination panel (points + 95% ellipses, centroids when >3 groups,
+## PERMANOVA R2/p annotation) - shared by the main figure's Weighted UniFrac
+## panels and the Bray-Curtis supplement.
+build_pcoa_panel <- function(meta, pcoa, block, dist_name, site_name, eth_colours) {
+    eig <- pcoa$values$Eigenvalues
+    var_explained <- round(100 * eig / sum(eig), 1)
+
+    ord_df <- data.frame(
+        PCo1 = pcoa$vectors[, 1],
+        PCo2 = pcoa$vectors[, 2],
+        EthnicityTotal = meta$EthnicityTotal
+    )
+
+    permanova_label <- paste0(
+        "R² = ", round(block$permanova_eth$R2[1], 3),
+        ", p = ", format.pval(block$permanova_eth[["Pr(>F)"]][1], digits = 2, eps = 0.001)
+    )
+
+    n_groups <- nlevels(droplevels(meta$EthnicityTotal))
+
+    p <- ggplot(ord_df, aes(x = PCo1, y = PCo2, colour = EthnicityTotal)) +
+        geom_point(alpha = 0.5, size = 1) +
+        stat_ellipse(level = 0.95, linewidth = 0.8)
+
+    if (n_groups > 3) {
+        centroids <- ord_df |>
+            group_by(EthnicityTotal) |>
+            summarise(PCo1 = mean(PCo1), PCo2 = mean(PCo2), .groups = "drop")
+        p <- p +
+            geom_point(data = centroids,
+                       aes(x = PCo1, y = PCo2, fill = EthnicityTotal),
+                       shape = 21, colour = "black", size = 4, stroke = 0.8) +
+            scale_fill_manual(values = eth_colours, guide = "none")
+    }
+
+    p <- p +
+        scale_colour_manual(values = eth_colours) +
+        annotate("text", x = Inf, y = Inf, label = permanova_label,
+                 hjust = 1.05, vjust = 1.5, size = 3.2) +
+        labs(x = paste0("PCo1 (", var_explained[1], "%)"),
+             y = paste0("PCo2 (", var_explained[2], "%)"),
+             colour = "Ethnicity",
+             title = paste0(dist_name, " - ", site_name)) +
+        guides(colour = guide_legend(nrow = 2, byrow = TRUE)) +
+        theme_Publication()
+
+    list(plot = p, n_groups = n_groups)
+}
+
+## Setup
+setwd(here::here())
+dir.create("results/figures", recursive = TRUE, showWarnings = FALSE)
+
+## Beta diversity cache must match whatever 7a_beta_diversity_16s_compute.R
+## was run with (BETA_DIV_TEST_N for a fast test cache, unset for the real one)
+test_n <- suppressWarnings(as.integer(Sys.getenv("BETA_DIV_TEST_N", "")))
+beta_outdir <- if (!is.na(test_n)) "results/beta_diversity_test" else "results/beta_diversity"
+if (!is.na(test_n)) cat("TEST MODE: reading beta diversity cache from", beta_outdir, "\n")
+
+## Ethnicity colours (same validated palette as scripts 6-8)
+eth_colours <- c(
+    "Dutch"                  = "#1F78B4",
+    "South-Asian Surinamese" = "#E31A1C",
+    "African Surinamese"     = "#33A02C",
+    "Javanese Surinamese"    = "#6A3D9A",
+    "Other"                  = "#B15928",
+    "Ghanaian"               = "#FF7F00",
+    "Turkish"                = "#E7298A",
+    "Moroccan"               = "#D4AC0D"
+)
+
+sites <- c("nose", "throat")
+
+## ---- Panels A/B: Shannon diversity boxplots ----
+shannon_panels <- list()
+
+for (site_name in sites) {
+    ps <- readRDS(paste0("data/processed/ps_", site_name, "_rarefied.RDS"))
+    ps <- subset_samples(ps, EthnicityTotal %in% keep_groups(ps))
+
+    alpha_df <- estimate_richness(ps, measures = "Shannon") |>
+        rownames_to_column("sample_id")
+
+    meta <- sample_data(ps) |>
+        as("data.frame") |>
+        rownames_to_column("sample_id") |>
+        select(sample_id, EthnicityTotal) |>
+        mutate(EthnicityTotal = droplevels(factor(EthnicityTotal)))
+
+    alpha_df <- alpha_df |>
+        left_join(meta, by = "sample_id") |>
+        filter(!is.na(EthnicityTotal))
+
+    ## Kruskal-Wallis omnibus + pairwise Wilcoxon (BH-adjusted), same
+    ## convention as 6_alpha_diversity_16s_ethnicity.R. Only p.adj < 0.05
+    ## pairs get a bracket - up to 10 (nose) or 15 (throat) possible pairs
+    ## would be unreadable if all were drawn.
+    pw <- pairwise.wilcox.test(alpha_df$Shannon, alpha_df$EthnicityTotal, p.adjust.method = "BH")
+    max_val <- max(alpha_df$Shannon)
+    min_val <- min(alpha_df$Shannon)
+    step <- (max_val - min_val) * 0.06
+
+    sig_pairs <- as.data.frame(as.table(pw$p.value)) |>
+        filter(!is.na(Freq)) |>
+        rename(group1 = Var1, group2 = Var2, p.adj = Freq) |>
+        filter(p.adj < 0.05) |>
+        arrange(p.adj) |>
+        mutate(
+            group1 = as.character(group1),
+            group2 = as.character(group2),
+            y.position = max_val + step * row_number(),
+            p.adj.label = case_when(
+                p.adj < 0.0001 ~ "****",
+                p.adj < 0.001  ~ "***",
+                p.adj < 0.01   ~ "**",
+                TRUE           ~ "*"
+            )
+        )
+
+    p_shannon <- ggplot(alpha_df, aes(x = EthnicityTotal, y = Shannon,
+                                       fill = EthnicityTotal)) +
+        geom_boxplot(outlier.shape = 21, outlier.size = 0.8, alpha = 0.7) +
+        stat_compare_means(method = "kruskal.test", label = "p.format") +
+        scale_fill_manual(values = eth_colours) +
+        labs(x = NULL, y = "Shannon index",
+             title = paste0("Shannon diversity - ", site_name)) +
+        scale_y_continuous(expand = expansion(mult = c(0.05, 0.2))) +
+        theme_Publication() +
+        theme(legend.position = "none",
+              axis.text.x = element_text(angle = 35, hjust = 1))
+
+    if (nrow(sig_pairs) > 0) {
+        p_shannon <- p_shannon +
+            ggpubr::stat_pvalue_manual(sig_pairs, label = "p.adj.label",
+                                        xmin = "group1", xmax = "group2",
+                                        y.position = "y.position",
+                                        tip.length = 0, size = 3,
+                                        color = "grey30")
+    }
+
+    shannon_panels[[site_name]] <- p_shannon
+}
+
+## ---- Panels C/D and E/F: PCoA (weighted UniFrac) and betadisper ----
+pcoa_panels <- list()
+betadisp_panels <- list()
+legend_source <- NULL
+caches <- list()
+
+for (site_name in sites) {
+    cache_path <- file.path(beta_outdir, "cache", paste0("beta_diversity_16s_", site_name, ".rds"))
+    if (!file.exists(cache_path)) {
+        stop("No beta diversity cache for '", site_name, "' at ", cache_path,
+             " - run scripts/7a_beta_diversity_16s_compute.R first.")
+    }
+    cache <- readRDS(cache_path)
+    caches[[site_name]] <- cache
+    meta  <- cache$meta
+    pcoa  <- cache$pcoas[["Weighted UniFrac"]]
+    block <- cache$blocks[["Weighted UniFrac"]]
+
+    ## PCoA
+    res <- build_pcoa_panel(meta, pcoa, block, "Weighted UniFrac", site_name, eth_colours)
+    p_pcoa <- res$plot
+    n_groups <- res$n_groups
+
+    ## The site with the most ethnicity groups gives the legend covering
+    ## every colour used anywhere in the figure
+    if (is.null(legend_source) || n_groups > legend_source$n_groups) {
+        legend_source <- list(plot = p_pcoa, n_groups = n_groups)
+    }
+
+    pcoa_panels[[site_name]] <- p_pcoa + theme(legend.position = "none")
+
+    ## Betadisper
+    disp_df <- data.frame(
+        Distance = block$betadisp$distances,
+        EthnicityTotal = meta$EthnicityTotal
+    )
+    betadisp_panels[[site_name]] <- ggplot(disp_df, aes(x = EthnicityTotal, y = Distance,
+                                                          fill = EthnicityTotal)) +
+        geom_boxplot(outlier.shape = 21, outlier.size = 0.8, alpha = 0.7) +
+        scale_fill_manual(values = eth_colours, guide = "none") +
+        labs(x = NULL, y = "Distance to centroid",
+             title = paste0("Betadisper - ", site_name),
+             subtitle = paste0("Permutest p = ",
+                               format.pval(block$betadisp_test$tab[["Pr(>F)"]][1], digits = 3))) +
+        theme_Publication() +
+        theme(legend.position = "none",
+              axis.text.x = element_text(angle = 35, hjust = 1))
+}
+
+shared_legend <- get_legend(legend_source$plot + theme(legend.position = "bottom"))
+
+## ---- Assemble ----
+grid <- plot_grid(
+    shannon_panels[["nose"]], shannon_panels[["throat"]],
+    pcoa_panels[["nose"]],    pcoa_panels[["throat"]],
+    betadisp_panels[["nose"]], betadisp_panels[["throat"]],
+    ncol = 2, labels = c("A", "B", "C", "D", "E", "F"),
+    rel_heights = c(1.1, 1.2, 1.1)
+)
+
+fig1 <- plot_grid(grid, shared_legend, ncol = 1, rel_heights = c(1, 0.06))
+
+ggsave("results/figures/figure1.pdf", plot = fig1, width = 10, height = 14)
+ggsave("results/figures/figure1.png", plot = fig1, width = 10, height = 14, dpi = 300)
+
+cat("Saved results/figures/figure1.pdf and .png\n")
+
+## ---- Supplement: Bray-Curtis PCoA (nose/throat side by side) ----
+## Reuses the cache objects already loaded above - no recompute.
+bc_panels <- list()
+bc_legend_source <- NULL
+
+for (site_name in sites) {
+    cache <- caches[[site_name]]
+    meta  <- cache$meta
+    pcoa  <- cache$pcoas[["Bray-Curtis"]]
+    block <- cache$blocks[["Bray-Curtis"]]
+
+    res <- build_pcoa_panel(meta, pcoa, block, "Bray-Curtis", site_name, eth_colours)
+
+    if (is.null(bc_legend_source) || res$n_groups > bc_legend_source$n_groups) {
+        bc_legend_source <- list(plot = res$plot, n_groups = res$n_groups)
+    }
+
+    bc_panels[[site_name]] <- res$plot + theme(legend.position = "none")
+}
+
+bc_shared_legend <- get_legend(bc_legend_source$plot + theme(legend.position = "bottom"))
+
+bc_grid <- plot_grid(
+    bc_panels[["nose"]], bc_panels[["throat"]],
+    ncol = 2, labels = c("A", "B")
+)
+
+fig1_supp_bc <- plot_grid(bc_grid, bc_shared_legend, ncol = 1, rel_heights = c(1, 0.12))
+
+ggsave("results/figures/figure1_supp_braycurtis_pcoa.pdf", plot = fig1_supp_bc, width = 10, height = 5.5)
+ggsave("results/figures/figure1_supp_braycurtis_pcoa.png", plot = fig1_supp_bc, width = 10, height = 5.5, dpi = 300)
+
+cat("Saved results/figures/figure1_supp_braycurtis_pcoa.pdf and .png\n")

--- a/scripts/13_figure2_assembly.R
+++ b/scripts/13_figure2_assembly.R
@@ -1,0 +1,361 @@
+## Figure 2 assembly: 16S throat/nose, stratified by ethnicity
+## Panels:
+##   A/B - Pairwise PERMANOVA (Weighted UniFrac, unadjusted) - nose/throat
+##   C/D - Covariate effects on beta diversity (both distance metrics) - nose/throat
+## Also writes a supplement (figure2_supp_braycurtis_pairwise.pdf/.png) with
+## Bray-Curtis pairwise PERMANOVA heatmaps: A/B unadjusted (nose/throat),
+## C/D adjusted for significant covariates (nose/throat).
+## Rebuilt from the .rds cache written by 7a_beta_diversity_16s_compute.R, so
+## this script never repeats a permutation test - run 7a first
+## (BETA_DIV_TEST_N=<n> for a fast test cache).
+
+## Libraries
+library(here)
+library(tidyverse)
+library(cowplot)
+library(grid)
+library(ggthemes)
+
+## Functions
+theme_Publication <- function(base_size=14, base_family="sans") {
+    library(grid)
+    library(ggthemes)
+    library(stringr)
+    (theme_foundation(base_size=base_size, base_family=base_family)
+        + theme(plot.title = element_text(face = "bold",
+                                          size = rel(1.0), hjust = 0.5),
+                text = element_text(),
+                panel.background = element_rect(colour = NA, fill = NA),
+                plot.background = element_rect(colour = NA, fill = NA),
+                panel.border = element_rect(colour = NA),
+                axis.title = element_text(face = "bold",size = rel(0.8)),
+                axis.title.y = element_text(angle=90, vjust =2),
+                axis.title.x = element_text(vjust = -0.2),
+                axis.text = element_text(size = rel(0.7)),
+                axis.text.x = element_text(angle = 0),
+                axis.line = element_line(colour="black"),
+                axis.ticks = element_line(),
+                panel.grid.major = element_line(colour="#f0f0f0"),
+                panel.grid.minor = element_blank(),
+                legend.key = element_rect(colour = NA),
+                legend.position = "bottom",
+                legend.key.size= unit(0.2, "cm"),
+                legend.spacing  = unit(0, "cm"),
+                plot.margin=unit(c(10,5,5,5),"mm"),
+                strip.background=element_rect(colour="#f0f0f0",fill="#f0f0f0"),
+                strip.text = element_text(face="bold"),
+                plot.caption = element_text(size = rel(0.5), face = "italic")
+        ))
+}
+
+## Word-wraps a title/subtitle to a fixed character width so it fits inside
+## the plot instead of running off the page (same helper as 7b's report script)
+wrap_for_plot <- function(x, width = 50) {
+    if (is.null(x)) return(list(text = NULL, n_lines = 0))
+    wrapped <- str_wrap(x, width = width)
+    list(text = wrapped, n_lines = lengths(regmatches(wrapped, gregexpr("\n", wrapped))) + 1)
+}
+
+## Pairwise PERMANOVA R2 heatmap (BH-adjusted significance stars) - same as
+## pairwise_permanova_heatmap() in 7b_beta_diversity_16s_report.R
+pairwise_permanova_heatmap <- function(pairwise_df, groups_order, title, subtitle = NULL,
+                                        fill_limits = c(0, NA)) {
+    pairwise_mat_df <- pairwise_df |>
+        select(group1, group2, R2, p.adj) |>
+        mutate(
+            group1 = factor(group1, levels = groups_order),
+            group2 = factor(group2, levels = groups_order),
+            sig = case_when(
+                p.adj < 0.0001 ~ "****",
+                p.adj < 0.001  ~ "***",
+                p.adj < 0.01   ~ "**",
+                p.adj < 0.05   ~ "*",
+                TRUE           ~ ""
+            ),
+            cell_label = paste0(sprintf("%.3f", R2), "\n", sig)
+        )
+
+    title_wrapped <- wrap_for_plot(title, width = 45)
+    subtitle_wrapped <- wrap_for_plot(subtitle, width = 62)
+
+    ggplot(pairwise_mat_df, aes(x = group1, y = group2, fill = R2)) +
+        geom_tile(colour = "white") +
+        geom_text(aes(label = cell_label), size = 3, lineheight = 0.9) +
+        scale_fill_gradient(low = "#F7F7F7", high = "#B2182B", limits = fill_limits) +
+        scale_x_discrete(drop = FALSE) +
+        scale_y_discrete(drop = FALSE) +
+        labs(x = NULL, y = NULL, fill = expression(R^2),
+             title = title_wrapped$text, subtitle = subtitle_wrapped$text,
+             caption = "BH-adjusted: * p<0.05, ** p<0.01, *** p<0.001, **** p<0.0001") +
+        theme_Publication() +
+        theme(axis.text.x = element_text(angle = 45, hjust = 1),
+              legend.position = "right",
+              panel.grid = element_blank(),
+              plot.subtitle = element_text(size = rel(0.55), face = "italic"))
+}
+
+## Setup
+setwd(here::here())
+dir.create("results/figures", recursive = TRUE, showWarnings = FALSE)
+
+## Beta diversity cache must match whatever 7a_beta_diversity_16s_compute.R
+## was run with (BETA_DIV_TEST_N for a fast test cache, unset for the real one)
+test_n <- suppressWarnings(as.integer(Sys.getenv("BETA_DIV_TEST_N", "")))
+beta_outdir <- if (!is.na(test_n)) "results/beta_diversity_test" else "results/beta_diversity"
+if (!is.na(test_n)) cat("TEST MODE: reading beta diversity cache from", beta_outdir, "\n")
+
+## Colours for the two distance metrics in the covariate-effect summary plot
+dist_colours <- c("Bray-Curtis" = "#2a78d6", "Weighted UniFrac" = "#eb6834")
+
+## Human-readable labels for the covariate-effect barplot
+covariate_labels <- c(
+    Age_FU               = "Age",
+    Sex                  = "Sex",
+    BMI_FU               = "BMI",
+    Smoking_FU           = "Smoking status",
+    AlcoholYN_FU         = "Alcohol use",
+    SBP_FU               = "Systolic blood pressure",
+    DBP_FU               = "Diastolic blood pressure",
+    HTSelfBP_FU          = "Hypertension",
+    DMSelfGluc_FU        = "Diabetes",
+    MetSyn_FU            = "Metabolic syndrome",
+    Antibiotics_FU       = "Antibiotics use",
+    Antihypertensiva_FU  = "Blood pressure lowering drugs",
+    Lipidlowering_FU     = "Lipid lowering drugs",
+    Corticosteroids_FU   = "Corticosteroids use",
+    SystemicSteroids_FU  = "Systemic steroids use",
+    Antihistamines_FU    = "Antihistamines use",
+    DecongAllerg_FU      = "Decongestant/allergy medication",
+    Antidepressants_FU   = "Antidepressants use",
+    Psychotropics_FU     = "Psychotropic medication use",
+    ToothBrushing_FU     = "Tooth brushing frequency",
+    TongueBrushing_FU    = "Tongue brushing frequency",
+    Mouthwash_FU         = "Mouthwash use",
+    OralHealth_FU        = "Self-rated oral health",
+    Nasal_FU             = "Nasal medication use",
+    PM10_mean            = "PM10 (2013-2015 mean)",
+    PM25_mean            = "PM2.5 (2013-2015 mean)",
+    NO2_mean             = "NO2 (2014-2015 mean)",
+    EC_mean              = "Soot/EC (2013-2015 mean)",
+    EthnicityTotal       = "Ethnicity"
+)
+
+sites <- c("nose", "throat")
+
+heatmap_panels <- list()
+adj_heatmap_panels <- list()
+barplot_panels <- list()
+n_terms_by_site <- list()
+legend_source <- NULL
+caches <- list()
+
+for (site_name in sites) {
+    cache_path <- file.path(beta_outdir, "cache", paste0("beta_diversity_16s_", site_name, ".rds"))
+    if (!file.exists(cache_path)) {
+        stop("No beta diversity cache for '", site_name, "' at ", cache_path,
+             " - run scripts/7a_beta_diversity_16s_compute.R first.")
+    }
+    cache <- readRDS(cache_path)
+    caches[[site_name]] <- cache
+    meta      <- cache$meta
+    distances <- cache$distances
+    blocks    <- cache$blocks
+    groups_order <- levels(droplevels(meta$EthnicityTotal))
+
+    ## ---- Panel A/B: pairwise PERMANOVA heatmap, Weighted UniFrac, unadjusted ----
+    wu_block <- blocks[["Weighted UniFrac"]]
+    heatmap_panels[[site_name]] <- pairwise_permanova_heatmap(
+        wu_block$permanova_pairwise, groups_order,
+        title = paste0("Pairwise differences - ", site_name),
+        fill_limits = c(0, max(wu_block$permanova_pairwise$R2))
+    )
+
+    ## ---- Panel E/F: pairwise PERMANOVA heatmap, Weighted UniFrac, adjusted
+    ## for that site's significant covariates (see pairwise_permanova_adjusted()
+    ## in 7a_beta_diversity_16s_compute.R). No subtitle listing the covariates
+    ## here - same fill scale as A/B (not its own max) so the shrinkage after
+    ## adjustment is visible directly by colour, title-only like A/B.
+    adj_heatmap_panels[[site_name]] <- pairwise_permanova_heatmap(
+        wu_block$permanova_pairwise_adjusted, groups_order,
+        title = paste0("Pairwise differences (adjusted) - ", site_name),
+        fill_limits = c(0, max(wu_block$permanova_pairwise$R2))
+    )
+
+    ## ---- Panel C/D: covariate effects on beta diversity, both distances ----
+    covariate_screen_all <- list()
+    for (dist_name in names(distances)) {
+        block <- blocks[[dist_name]]
+        covariate_screen_all[[dist_name]] <- bind_rows(
+            tibble(covariate = "EthnicityTotal", Df = block$permanova_eth$Df[1],
+                   R2 = block$permanova_eth$R2[1], F_stat = block$permanova_eth$F[1],
+                   p.value = block$permanova_eth[["Pr(>F)"]][1]),
+            block$covariate_screen
+        ) |> mutate(distance = dist_name)
+    }
+    covariate_effects <- bind_rows(covariate_screen_all)
+
+    covariate_order <- covariate_effects |>
+        filter(covariate != "EthnicityTotal") |>
+        group_by(covariate) |>
+        summarise(max_R2 = max(R2), .groups = "drop") |>
+        arrange(max_R2) |>
+        pull(covariate)
+    covariate_effects <- covariate_effects |>
+        mutate(covariate_label = covariate_labels[covariate],
+               covariate_label = factor(covariate_label,
+                                        levels = covariate_labels[c(covariate_order, "EthnicityTotal")]),
+               significant = p.value < 0.05)
+
+    n_terms_by_site[[site_name]] <- n_distinct(covariate_effects$covariate_label)
+
+    p_bar <- ggplot(covariate_effects, aes(x = covariate_label, y = R2, fill = distance,
+                                            colour = distance, alpha = significant)) +
+        geom_col(position = position_dodge(width = 0.7), width = 0.6, linewidth = 0.6) +
+        coord_flip() +
+        scale_fill_manual(values = dist_colours) +
+        scale_colour_manual(values = dist_colours, guide = "none") +
+        scale_alpha_manual(values = c(`TRUE` = 1, `FALSE` = 0), guide = "none") +
+        labs(x = NULL, y = expression(R^2), fill = "Distance metric",
+             title = paste0("Covariate effects - ", site_name),
+             caption = "Filled bars: p < 0.05 (PERMANOVA)") +
+        theme_Publication()
+
+    if (is.null(legend_source)) legend_source <- p_bar
+
+    barplot_panels[[site_name]] <- p_bar + theme(legend.position = "none")
+
+    cat("Completed:", site_name, "\n")
+}
+
+shared_legend <- get_legend(legend_source + theme(legend.position = "bottom"))
+
+## ---- Assemble ----
+## Covariate barplots carry far more categories than the heatmaps have
+## ethnicity groups, so the middle row gets proportionally more height.
+grid <- plot_grid(
+    heatmap_panels[["nose"]], heatmap_panels[["throat"]],
+    barplot_panels[["nose"]], barplot_panels[["throat"]],
+    adj_heatmap_panels[["nose"]], adj_heatmap_panels[["throat"]],
+    ncol = 2, labels = c("A", "B", "C", "D", "E", "F"),
+    rel_heights = c(0.8, 1.6, 0.8)
+)
+
+fig2 <- plot_grid(grid, shared_legend, ncol = 1, rel_heights = c(1, 0.04))
+
+ggsave("results/figures/figure2.pdf", plot = fig2, width = 14, height = 21.5)
+ggsave("results/figures/figure2.png", plot = fig2, width = 14, height = 21.5, dpi = 300)
+
+cat("Saved results/figures/figure2.pdf and .png\n")
+
+## ---- Supplement: Bray-Curtis pairwise PERMANOVA, unadjusted vs adjusted ----
+## Reuses the cache objects already loaded above - no recompute. Unadjusted
+## and adjusted heatmaps for the same site share one colour scale (as in
+## 7b's per-site heatmaps) so the two are visually comparable.
+bc_pairwise_panels <- list()
+
+for (site_name in sites) {
+    cache <- caches[[site_name]]
+    meta  <- cache$meta
+    block <- cache$blocks[["Bray-Curtis"]]
+    groups_order <- levels(droplevels(meta$EthnicityTotal))
+
+    shared_max <- max(block$permanova_pairwise$R2, block$permanova_pairwise_adjusted$R2)
+
+    adjusted_subtitle <- if (length(block$sig_covariates) > 0) {
+        paste0("Adjusted for: ", paste(covariate_labels[block$sig_covariates], collapse = ", "))
+    } else {
+        "No significant covariates - same as unadjusted"
+    }
+
+    bc_pairwise_panels[[paste0(site_name, "_unadj")]] <- pairwise_permanova_heatmap(
+        block$permanova_pairwise, groups_order,
+        title = paste0("Bray-Curtis pairwise (unadjusted) - ", site_name),
+        fill_limits = c(0, shared_max)
+    )
+    bc_pairwise_panels[[paste0(site_name, "_adj")]] <- pairwise_permanova_heatmap(
+        block$permanova_pairwise_adjusted, groups_order,
+        title = paste0("Bray-Curtis pairwise (adjusted) - ", site_name),
+        subtitle = adjusted_subtitle,
+        fill_limits = c(0, shared_max)
+    )
+}
+
+bc_grid <- plot_grid(
+    bc_pairwise_panels[["nose_unadj"]],   bc_pairwise_panels[["throat_unadj"]],
+    bc_pairwise_panels[["nose_adj"]],     bc_pairwise_panels[["throat_adj"]],
+    ncol = 2, labels = c("A", "B", "C", "D")
+)
+
+## Fixed height (not dynamically sized to the adjusted panels' subtitle,
+## unlike 7b's per-panel plots) - generous enough for the wrapped covariate
+## list subtitle on the adjusted row
+ggsave("results/figures/figure2_supp_braycurtis_pairwise.pdf", plot = bc_grid,
+       width = 12, height = 13)
+ggsave("results/figures/figure2_supp_braycurtis_pairwise.png", plot = bc_grid,
+       width = 12, height = 13, dpi = 300)
+
+cat("Saved results/figures/figure2_supp_braycurtis_pairwise.pdf and .png\n")
+
+## ---- Supplement: ethnicity attenuation by covariate, nose vs throat ----
+## Reuses the cache objects already loaded above - no recompute. Same
+## summary plot as 7b_beta_diversity_16s_report.R's per-site attenuation
+## plot (abs_reduction = how much ethnicity's PERMANOVA R2 drops once that
+## one covariate is adjusted for), just nose and throat assembled side by
+## side instead of as two separate per-site files.
+attenuation_panels <- list()
+attenuation_legend_source <- NULL
+
+for (site_name in sites) {
+    blocks <- caches[[site_name]]$blocks
+
+    attenuation_effects <- map(names(blocks), function(dist_name) {
+        blocks[[dist_name]]$ethnicity_attenuation |> mutate(distance = dist_name)
+    }) |> bind_rows()
+
+    attenuation_order <- attenuation_effects |>
+        group_by(covariate) |>
+        summarise(max_reduction = max(abs_reduction), .groups = "drop") |>
+        arrange(max_reduction) |>
+        pull(covariate)
+    attenuation_effects <- attenuation_effects |>
+        mutate(covariate_label = covariate_labels[covariate],
+               covariate_label = factor(covariate_label,
+                                        levels = covariate_labels[attenuation_order]),
+               significant = p_value < 0.05)
+
+    p_atten <- ggplot(attenuation_effects, aes(x = covariate_label, y = abs_reduction,
+                                                fill = distance, colour = distance,
+                                                alpha = significant)) +
+        geom_col(position = position_dodge(width = 0.7), width = 0.6, linewidth = 0.6) +
+        coord_flip() +
+        scale_fill_manual(values = dist_colours) +
+        scale_colour_manual(values = dist_colours, guide = "none") +
+        scale_alpha_manual(values = c(`TRUE` = 1, `FALSE` = 0), guide = "none") +
+        labs(x = NULL, y = expression("Reduction in ethnicity" ~ R^2),
+             fill = "Distance metric",
+             title = paste0("Ethnicity attenuation - ", site_name),
+             caption = "Filled bars: p < 0.05 for ethnicity net of covariate (PERMANOVA)") +
+        theme_Publication()
+
+    if (is.null(attenuation_legend_source)) attenuation_legend_source <- p_atten
+
+    attenuation_panels[[site_name]] <- p_atten + theme(legend.position = "none")
+}
+
+attenuation_legend <- get_legend(attenuation_legend_source + theme(legend.position = "bottom"))
+
+n_atten_terms <- max(vapply(attenuation_panels,
+                            function(p) n_distinct(p$data$covariate_label), integer(1)))
+
+atten_grid <- plot_grid(
+    attenuation_panels[["nose"]], attenuation_panels[["throat"]],
+    ncol = 2, labels = c("A", "B")
+)
+atten_fig <- plot_grid(atten_grid, attenuation_legend, ncol = 1, rel_heights = c(1, 0.06))
+
+ggsave("results/figures/figure2_supp_ethnicity_attenuation.pdf", plot = atten_fig,
+       width = 14, height = max(6, 0.3 * n_atten_terms + 2))
+ggsave("results/figures/figure2_supp_ethnicity_attenuation.png", plot = atten_fig,
+       width = 14, height = max(6, 0.3 * n_atten_terms + 2), dpi = 300)
+
+cat("Saved results/figures/figure2_supp_ethnicity_attenuation.pdf and .png\n")

--- a/scripts/14_figure3_assembly.R
+++ b/scripts/14_figure3_assembly.R
@@ -1,0 +1,314 @@
+## Figure 3 assembly: 16S throat/nose differential abundance (ethnicity)
+## Main figure panels:
+##   A/B - Pairwise DA taxa count heatmap (q < 0.05), nose/throat - summarizes
+##         all 10/15 pairwise MaAsLin2 models at a glance
+##   C     - Volcano plot, nose: Dutch vs African Surinamese (best nose signal)
+##   D/E/F - Volcano plots, throat: Dutch vs South-Asian Surinamese (strongest
+##           signal), Dutch vs Ghanaian (second-strongest), Ghanaian vs
+##           Moroccan (non-Dutch pair with strong signal, shows migrant-
+##           migrant divergence is real too)
+## Also writes two supplementary grids (not part of the lettered main
+## figure) with every pairwise volcano plot for a site, so the pairs not
+## featured above are still available for the supplement.
+## Volcano plots have no adjustment-set subtitle - state it in the figure
+## legend instead (same adjustment set for every pair at a site, see
+## results/differential_abundance/confounder_assessment/, printed below).
+## Rebuilt from the per-pair MaAsLin2 CSVs already written by
+## 9_differential_abundance_16s.R, so this script never refits anything -
+## run 9 first (DIFF_AB_TEST_N=<n> for a fast test run, matched here).
+
+## Libraries
+library(here)
+library(tidyverse)
+library(cowplot)
+library(grid)
+library(ggthemes)
+
+## Functions
+theme_Publication <- function(base_size=14, base_family="sans") {
+    library(grid)
+    library(ggthemes)
+    library(stringr)
+    (theme_foundation(base_size=base_size, base_family=base_family)
+        + theme(plot.title = element_text(face = "bold",
+                                          size = rel(1.0), hjust = 0.5),
+                text = element_text(),
+                panel.background = element_rect(colour = NA, fill = NA),
+                plot.background = element_rect(colour = NA, fill = NA),
+                panel.border = element_rect(colour = NA),
+                axis.title = element_text(face = "bold",size = rel(0.8)),
+                axis.title.y = element_text(angle=90, vjust =2),
+                axis.title.x = element_text(vjust = -0.2),
+                axis.text = element_text(size = rel(0.7)),
+                axis.text.x = element_text(angle = 0),
+                axis.line = element_line(colour="black"),
+                axis.ticks = element_line(),
+                panel.grid.major = element_line(colour="#f0f0f0"),
+                panel.grid.minor = element_blank(),
+                legend.key = element_rect(colour = NA),
+                legend.position = "bottom",
+                legend.key.size= unit(0.2, "cm"),
+                legend.spacing  = unit(0, "cm"),
+                plot.margin=unit(c(10,5,5,5),"mm"),
+                strip.background=element_rect(colour="#f0f0f0",fill="#f0f0f0"),
+                strip.text = element_text(face="bold"),
+                plot.caption = element_text(size = rel(0.5), face = "italic")
+        ))
+}
+
+## Shorten covariate names for plot subtitles (drop trailing _FU/_BA suffix)
+## and wrap long lists onto multiple lines instead of running off the page.
+## (same helper as 9_differential_abundance_16s.R)
+format_covariates <- function(covs, width = 70) {
+    covs |>
+        gsub("_(FU|BA)$", "", x = _) |>
+        paste(collapse = ", ") |>
+        str_wrap(width = width)
+}
+
+## Short abbreviations for filenames (group names contain spaces/hyphens) -
+## same lookup as 9_differential_abundance_16s.R, needed here to rebuild the
+## pair_tag used in its output filenames.
+eth_abbrev <- c(
+    "Dutch" = "Dutch",
+    "South-Asian Surinamese" = "SAS",
+    "African Surinamese" = "AfrSur",
+    "Javanese Surinamese" = "JavSur",
+    "Other" = "Other",
+    "Ghanaian" = "Ghanaian",
+    "Turkish" = "Turkish",
+    "Moroccan" = "Moroccan"
+)
+pair_name <- function(g1, g2) paste0(eth_abbrev[[g1]], "_vs_", eth_abbrev[[g2]])
+
+eth_colours <- c(
+    "Dutch"                  = "#1F78B4",
+    "South-Asian Surinamese" = "#E31A1C",
+    "African Surinamese"     = "#33A02C",
+    "Javanese Surinamese"    = "#6A3D9A",
+    "Other"                  = "#B15928",
+    "Ghanaian"               = "#FF7F00",
+    "Turkish"                = "#E7298A",
+    "Moroccan"               = "#D4AC0D"
+)
+
+## Pairwise DA taxa count heatmap - same visual convention as the pairwise
+## PERMANOVA heatmap in 13_figure2_assembly.R (upper-triangle tile grid,
+## sequential fill), but cells hold a DA taxa count instead of R2.
+pairwise_sig_heatmap <- function(pair_counts, groups_order, title, fill_limits = c(0, NA)) {
+    pair_counts <- pair_counts |>
+        mutate(group1 = factor(group1, levels = groups_order),
+               group2 = factor(group2, levels = groups_order))
+
+    ggplot(pair_counts, aes(x = group1, y = group2, fill = n_sig)) +
+        geom_tile(colour = "white") +
+        geom_text(aes(label = n_sig), size = 3.5) +
+        scale_fill_gradient(low = "#F7F7F7", high = "#B2182B", limits = fill_limits) +
+        scale_x_discrete(drop = FALSE) +
+        scale_y_discrete(drop = FALSE) +
+        labs(x = NULL, y = NULL, fill = "Differentially\nabundant microbes\n(q < 0.05)", title = title) +
+        guides(fill = guide_colorbar(barheight = unit(1.8, "cm"), barwidth = unit(0.3, "cm"))) +
+        theme_Publication() +
+        theme(axis.text.x = element_text(angle = 45, hjust = 1),
+              legend.position = "right",
+              panel.grid = element_blank())
+}
+
+## Volcano plot for a single pair, rebuilt from the MaAsLin2 CSV already
+## written by 9_differential_abundance_16s.R (no refitting). Mirrors that
+## script's volcano code, minus the file save and the adjustment-set
+## subtitle (stated once in the figure legend instead - see
+## site_confounder_label() below). label_n/title_site are lower/simpler
+## for the all-pairs supplementary grids than for the main figure's
+## highlighted panels.
+build_volcano <- function(diffab_dir, site_name, group1, group2,
+                           label_n = 10, title_site = TRUE) {
+    pair_tag <- pair_name(group1, group2)
+    g1_abbr <- eth_abbrev[[group1]]
+    g2_abbr <- eth_abbrev[[group2]]
+
+    res_eth <- read_csv(
+        file.path(diffab_dir, "maaslin2",
+                  paste0("maaslin2_ethnicity_results_16s_", site_name, "_", pair_tag, ".csv")),
+        show_col_types = FALSE
+    )
+
+    res_eth <- res_eth |>
+        mutate(
+            sig = case_when(
+                qval < 0.05 ~ "q < 0.05",
+                TRUE ~ "NS"
+            ),
+            label = case_when(
+                !is.na(Tax) & Tax != "" ~ Tax,
+                TRUE ~ feature
+            )
+        ) |>
+        group_by(label) |>
+        mutate(label = if (n() > 1) paste0(label, " (", feature, ")") else label) |>
+        ungroup()
+
+    volcano_colours <- c("q < 0.05" = "#E31A1C", "NS" = "grey60")
+
+    p <- ggplot(res_eth, aes(x = coef, y = -log10(qval), colour = sig)) +
+        geom_point(alpha = 0.7, size = 1.5) +
+        geom_hline(yintercept = -log10(0.05), linetype = "dashed", colour = "grey40") +
+        scale_colour_manual(values = volcano_colours) +
+        labs(x = paste0("Coefficient (", group2, " vs ", group1, ")"),
+             y = expression(-log[10](q-value)),
+             colour = "Significance",
+             title = if (title_site) paste0(site_name, ": ", g1_abbr, " vs ", g2_abbr)
+                     else paste0(g1_abbr, " vs ", g2_abbr)) +
+        theme_Publication() +
+        theme(legend.position = "right")
+
+    top_taxa <- res_eth |>
+        filter(qval < 0.05) |>
+        slice_min(qval, n = label_n)
+
+    if (nrow(top_taxa) > 0) {
+        p <- p +
+            ggrepel::geom_text_repel(
+                data = top_taxa,
+                aes(label = label),
+                size = 2.3, max.overlaps = 15,
+                show.legend = FALSE
+            )
+    }
+
+    p
+}
+
+## Significant-confounder set for a site, formatted for the figure legend
+## text (same set adjusted for in every pairwise model at that site - see
+## 9_differential_abundance_16s.R's assess_confounders()).
+site_confounder_label <- function(diffab_dir, site_name) {
+    sig_confounders <- read_csv(
+        file.path(diffab_dir, "confounder_assessment",
+                  paste0("confounder_assessment_16s_", site_name, ".csv")),
+        show_col_types = FALSE
+    ) |>
+        filter(p.value < 0.05) |>
+        pull(covariate)
+    format_covariates(sig_confounders, width = 200)
+}
+
+## Grid of every pairwise volcano plot at a site (10 at nose, 15 at
+## throat) - the supplementary counterpart to the main figure's 4
+## highlighted pairs.
+assemble_site_volcanoes <- function(diffab_dir, site_name, summary_pairs, ncol = 3, label_n = 6) {
+    pairs <- summary_pairs |> filter(site == site_name)
+    plots <- map2(pairs$group1, pairs$group2, function(g1, g2) {
+        build_volcano(diffab_dir, site_name, g1, g2, label_n = label_n, title_site = FALSE) +
+            theme(legend.position = "none")
+    })
+    shared_legend <- get_legend(
+        build_volcano(diffab_dir, site_name, pairs$group1[1], pairs$group2[1],
+                      label_n = label_n, title_site = FALSE) +
+            theme(legend.position = "bottom")
+    )
+    n_rows <- ceiling(length(plots) / ncol)
+    grid <- plot_grid(plotlist = plots, ncol = ncol)
+    plot_grid(grid, shared_legend, ncol = 1, rel_heights = c(n_rows, 0.4))
+}
+
+## Setup
+setwd(here::here())
+dir.create("results/figures", recursive = TRUE, showWarnings = FALSE)
+
+## Differential abundance results must match whatever
+## 9_differential_abundance_16s.R was run with (DIFF_AB_TEST_N for a fast
+## test run, unset for the real one)
+test_n <- suppressWarnings(as.integer(Sys.getenv("DIFF_AB_TEST_N", "")))
+diffab_dir <- if (!is.na(test_n)) "results/differential_abundance_test" else "results/differential_abundance"
+if (!is.na(test_n)) cat("TEST MODE: reading differential abundance results from", diffab_dir, "\n")
+
+## ---- Panels A/B: pairwise DA taxa count heatmap, nose/throat ----
+summary_pairs <- read_csv(file.path(diffab_dir, "summary_pairs_16s.csv"), show_col_types = FALSE)
+
+## n_sig per pair: count qval < 0.05 in each pair's MaAsLin2 results (same
+## threshold as the forest plots and the upset plot in 10_upset_diffabund_16s.R)
+summary_pairs <- summary_pairs |>
+    rowwise() |>
+    mutate(n_sig = {
+        f <- file.path(diffab_dir, "maaslin2",
+                       paste0("maaslin2_ethnicity_results_16s_", site, "_",
+                              pair_name(group1, group2), ".csv"))
+        sum(read_csv(f, show_col_types = FALSE)$qval < 0.05, na.rm = TRUE)
+    }) |>
+    ungroup()
+
+heatmap_panels <- list()
+sites <- c("nose", "throat")
+
+for (site_name in sites) {
+    pair_counts <- summary_pairs |> filter(site == site_name)
+    groups_order <- names(eth_colours)[names(eth_colours) %in%
+                                        unique(c(pair_counts$group1, pair_counts$group2))]
+
+    heatmap_panels[[site_name]] <- pairwise_sig_heatmap(
+        pair_counts, groups_order,
+        title = paste0("Pairwise DA: ", site_name),
+        fill_limits = c(0, max(pair_counts$n_sig))
+    )
+}
+
+## ---- Panel C: nose volcano highlight ----
+## Dutch vs African Surinamese: best signal at this site (36/12); nose is
+## underpowered everywhere else, so one panel represents it.
+p_nose_1 <- build_volcano(diffab_dir, "nose", "Dutch", "African Surinamese")
+
+## ---- Panels D/E/F: throat volcano highlights ----
+## Dutch vs SAS: strongest signal (160 taxa q<0.25, 116 q<0.05). Dutch vs
+## Ghanaian: second-strongest (106/72). Ghanaian vs Moroccan: strong signal
+## (62/39) between two non-Dutch groups, showing migrant-migrant divergence
+## is real, not just host-vs-migrant.
+p_throat_1 <- build_volcano(diffab_dir, "throat", "Dutch", "South-Asian Surinamese")
+p_throat_2 <- build_volcano(diffab_dir, "throat", "Dutch", "Ghanaian")
+p_throat_3 <- build_volcano(diffab_dir, "throat", "Ghanaian", "Moroccan")
+
+volcano_panels <- list(p_nose_1, p_throat_1, p_throat_2, p_throat_3)
+shared_legend <- get_legend(volcano_panels[[1]] + theme(legend.position = "bottom"))
+volcano_panels <- lapply(volcano_panels, function(p) p + theme(legend.position = "none"))
+
+## ---- Assemble ----
+grid <- plot_grid(
+    heatmap_panels[["nose"]], heatmap_panels[["throat"]],
+    volcano_panels[[1]], volcano_panels[[2]],
+    volcano_panels[[3]], volcano_panels[[4]],
+    ncol = 2, labels = c("A", "B", "C", "D", "E", "F"),
+    rel_heights = c(0.8, 1.2, 1.2)
+)
+
+fig3 <- plot_grid(grid, shared_legend, ncol = 1, rel_heights = c(1, 0.04))
+
+ggsave("results/figures/figure3.pdf", plot = fig3, width = 14, height = 16)
+ggsave("results/figures/figure3.png", plot = fig3, width = 14, height = 16, dpi = 300)
+
+cat("Saved results/figures/figure3.pdf and .png\n")
+
+## ---- Supplement: every pairwise volcano plot, per site ----
+## Not part of the lettered main figure - covers all 10 (nose) / 15 (throat)
+## pairs, including the ones not highlighted above.
+supp_nose <- assemble_site_volcanoes(diffab_dir, "nose", summary_pairs, ncol = 3)
+n_rows_nose <- ceiling(sum(summary_pairs$site == "nose") / 3)
+ggsave("results/figures/figure3_supp_nose_volcanoes.pdf", plot = supp_nose,
+       width = 14, height = 4.5 * n_rows_nose + 1, limitsize = FALSE)
+ggsave("results/figures/figure3_supp_nose_volcanoes.png", plot = supp_nose,
+       width = 14, height = 4.5 * n_rows_nose + 1, dpi = 300, limitsize = FALSE)
+
+supp_throat <- assemble_site_volcanoes(diffab_dir, "throat", summary_pairs, ncol = 3)
+n_rows_throat <- ceiling(sum(summary_pairs$site == "throat") / 3)
+ggsave("results/figures/figure3_supp_throat_volcanoes.pdf", plot = supp_throat,
+       width = 14, height = 4.5 * n_rows_throat + 1, limitsize = FALSE)
+ggsave("results/figures/figure3_supp_throat_volcanoes.png", plot = supp_throat,
+       width = 14, height = 4.5 * n_rows_throat + 1, dpi = 300, limitsize = FALSE)
+
+cat("Saved results/figures/figure3_supp_nose_volcanoes.pdf/.png and",
+    "figure3_supp_throat_volcanoes.pdf/.png\n")
+
+## Adjustment set per site, for the figure legend text (subtitles were
+## dropped from the plots themselves)
+for (site_name in sites) {
+    cat(site_name, "- adjusted for:", site_confounder_label(diffab_dir, site_name), "\n")
+}

--- a/scripts/6_alpha_diversity_16s_ethnicity.R
+++ b/scripts/6_alpha_diversity_16s_ethnicity.R
@@ -100,11 +100,8 @@ sites <- list(
     nose   = readRDS("data/processed/ps_nose_rarefied.RDS")
 )
 
-rarefaction_depths <- c(throat = 7500, nose = 2000)
-
 for (site_name in names(sites)) {
     ps <- sites[[site_name]]
-    rare_depth <- rarefaction_depths[[site_name]]
 
     ## Filter to ethnicity groups with N > 50 in this site
     ps <- subset_samples(ps, EthnicityTotal %in% keep_groups(ps))
@@ -195,7 +192,7 @@ for (site_name in names(sites)) {
         mutate(
             group1 = as.character(group1),
             group2 = as.character(group2),
-            step = (max_val - min_val) * 0.12,
+            step = (max_val - min_val) * 0.06,
             y.position = max_val + step * row_number(),
             p.adj.label = case_when(
                 p.adj < 0.0001 ~ "****",
@@ -211,23 +208,20 @@ for (site_name in names(sites)) {
         stat_compare_means(method = "kruskal.test", label = "p.format") +
         facet_wrap(~ metric, scales = "free_y", nrow = 1) +
         scale_fill_manual(values = eth_colours) +
-        labs(x = NULL, y = "Value", fill = "Ethnicity",
-             title = paste0("Alpha diversity by ethnicity - 16S ", site_name),
-             caption = paste0("Rarefied to ", format(rare_depth, big.mark = ","),
-                              " reads/sample. Kruskal-Wallis omnibus test across all groups; ",
-                              "brackets show pairwise Wilcoxon (BH-adjusted) p < 0.05 only - ",
-                              "full pairwise results in results CSV.")) +
+        labs(x = NULL, y = "Value",
+             title = paste0("Alpha diversity by ethnicity - 16S ", site_name)) +
         scale_y_continuous(expand = expansion(mult = c(0.05, 0.2))) +
-        guides(fill = guide_legend(nrow = 2, byrow = TRUE)) +
         theme_Publication() +
-        theme(axis.text.x = element_text(angle = 25, hjust = 1))
+        theme(legend.position = "none",
+              axis.text.x = element_text(angle = 25, hjust = 1))
 
     if (nrow(sig_pairs) > 0) {
         p_box <- p_box +
             ggpubr::stat_pvalue_manual(sig_pairs, label = "p.adj.label",
                                         xmin = "group1", xmax = "group2",
                                         y.position = "y.position",
-                                        tip.length = 0.01, size = 3)
+                                        tip.length = 0, size = 3,
+                                        color = "grey30")
     }
 
     ggsave(paste0("results/alpha_diversity/alpha_diversity_boxplot_16s_",
@@ -241,13 +235,11 @@ for (site_name in names(sites)) {
                      outlier.shape = 21, outlier.size = 0.8) +
         facet_wrap(~ metric, scales = "free_y", nrow = 1) +
         scale_fill_manual(values = eth_colours) +
-        labs(x = NULL, y = "Value", fill = "Ethnicity",
-             title = paste0("Alpha diversity distribution - 16S ", site_name),
-             caption = paste0("Rarefied to ", format(rare_depth, big.mark = ","),
-                              " reads/sample")) +
-        guides(fill = guide_legend(nrow = 2, byrow = TRUE)) +
+        labs(x = NULL, y = "Value",
+             title = paste0("Alpha diversity distribution - 16S ", site_name)) +
         theme_Publication() +
-        theme(axis.text.x = element_text(angle = 25, hjust = 1))
+        theme(legend.position = "none",
+              axis.text.x = element_text(angle = 25, hjust = 1))
     ggsave(paste0("results/alpha_diversity/alpha_diversity_violin_16s_",
                   site_name, "_ethnicity.pdf"),
            width = 12, height = 6.5)

--- a/scripts/7b_beta_diversity_16s_report.R
+++ b/scripts/7b_beta_diversity_16s_report.R
@@ -505,13 +505,6 @@ for (site_name in c("throat", "nose")) {
               paste0(outdir, "/permanova/ethnicity_attenuation_summary_16s_", site_name, ".csv"))
 
     n_atten_terms <- n_distinct(attenuation_effects$covariate_label)
-    ## Wrapped and shrunk the same way pairwise_permanova_heatmap() handles
-    ## its subtitle - theme_Publication() doesn't style plot.subtitle at all,
-    ## so left at ggplot2's default size it runs off an 8" wide plot.
-    atten_subtitle <- wrap_for_plot(
-        "Drop in ethnicity's PERMANOVA R2 when adjusted for that covariate alone",
-        width = 75
-    )
     ggplot(attenuation_effects, aes(x = covariate_label, y = abs_reduction, fill = distance,
                                      colour = distance, alpha = significant)) +
         geom_col(position = position_dodge(width = 0.7), width = 0.6, linewidth = 0.6) +
@@ -522,12 +515,10 @@ for (site_name in c("throat", "nose")) {
         labs(x = NULL, y = expression("Reduction in ethnicity" ~ R^2),
              fill = "Distance metric",
              title = paste0("Ethnicity attenuation by covariate - 16S ", site_name),
-             subtitle = atten_subtitle$text,
              caption = "Filled bars: p < 0.05 for ethnicity net of covariate (PERMANOVA)") +
-        theme_Publication() +
-        theme(plot.subtitle = element_text(size = rel(0.6), face = "italic", hjust = 0.5))
+        theme_Publication()
     ggsave(paste0(outdir, "/permanova/ethnicity_attenuation_summary_16s_", site_name, ".pdf"),
-           width = 8, height = max(6, 0.3 * n_atten_terms + 2) + 0.17 * atten_subtitle$n_lines)
+           width = 8, height = max(6, 0.3 * n_atten_terms + 2))
 
     cat("Finished site:", site_name, "-", n_samples, "samples\n\n")
 }


### PR DESCRIPTION
## Summary
- Add three new scripts that assemble the manuscript's main figures directly from already-computed results (rarefied phyloseq objects and the 7a/9 result caches), so no permutation test or MaAsLin2 model is ever repeated:
  - `12_figure1_assembly.R` — Shannon diversity, weighted UniFrac PCoA, and betadisper panels (nose/throat), plus a Bray-Curtis PCoA supplement
  - `13_figure2_assembly.R` — pairwise PERMANOVA heatmaps (unadjusted and covariate-adjusted) and covariate-effects barplots (nose/throat), plus a Bray-Curtis pairwise PERMANOVA supplement
  - `14_figure3_assembly.R` — pairwise DA taxa count heatmap and four highlighted volcano plots (nose/throat), plus per-site supplementary volcano grids
- Lightly simplify `6_alpha_diversity_16s_ethnicity.R` and `7b_beta_diversity_16s_report.R` styling so their plots compose cleanly into the new multi-panel figures
- Wire up `pixi.toml`: add the `figure1`/`figure2` tasks to the pipeline and add the `r-cowplot` dependency the new scripts need

## Test plan
- [x] `pixi run figure1` / `pixi run figure2` produce `results/figures/figure1.pdf`/`figure2.pdf` without errors (requires `7a_beta_diversity_16s_compute.R` cache to exist)
- [x] `Rscript scripts/14_figure3_assembly.R` produces `results/figures/figure3.pdf` (requires `9_differential_abundance_16s.R` output to exist)
- [x] Visually review the three figures and their supplements for correct panel layout/labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)